### PR TITLE
[REF] Improve readability of KFAC utilities

### DIFF
--- a/singd/optim/utils.py
+++ b/singd/optim/utils.py
@@ -28,9 +28,9 @@ def _extract_patches(
         groups: The number of channel groups.
 
     Returns:
-        A tensor of shape `[batch_size, O1 * O2, C_in * K1 * K2]` where each column
-        `[b, o1_o2, :]` contains the flattened patch of sample `b` used for output
-        location `(o1, o2)`.
+        A tensor of shape `[batch_size, O1 * O2, C_in // groups * K1 * K2]` where
+        each column `[b, o1_o2, :]` contains the flattened patch of sample `b` used
+        for output location `(o1, o2)`, averaged over channel groups.
     """
     x_unfold = F.unfold(x, kernel_size, dilation=1, padding=padding, stride=stride)
     # separate the channel groups
@@ -40,42 +40,45 @@ def _extract_patches(
     return reduce(x_unfold, "b g c_in_k1_k2 o1_o2 -> b o1_o2 c_in_k1_k2", "mean")
 
 
-def process_input(input: Tensor, module: Module, kfac_approx: str) -> Tensor:
+def process_input(x: Tensor, module: Module, kfac_approx: str) -> Tensor:
     """Unfold the input for convolutions, append ones if biases are present.
 
     Args:
-        input: The input to the module.
+        x: The input to the module.
         module: The module.
         kfac_approx: The KFAC approximation to use for linear weight-sharing
-            layers. Possible values are `'expand'` and `'reduce'`.
+            layers. Possible values are `"expand"` and `"reduce"`.
 
     Returns:
         The processed input.
 
     Raises:
-        AssertionError: If `kfac_approx` is neither `'expand'` nor `'reduce'`.
+        AssertionError: If `kfac_approx` is neither `"expand"` nor `"reduce"`.
         NotImplementedError: If the module is not supported.
     """
     assert kfac_approx in {"expand", "reduce"}
     if isinstance(module, Conv2d):
-        return conv2d_process_input(input, module, kfac_approx)
+        return conv2d_process_input(x, module, kfac_approx)
     elif isinstance(module, Linear):
-        return linear_process_input(input, module, kfac_approx)
+        return linear_process_input(x, module, kfac_approx)
     else:
         raise NotImplementedError(f"Can't process input for {module}.")
 
 
-def conv2d_process_input(a: Tensor, layer: Conv2d, kfac_approx: str) -> Tensor:
+def conv2d_process_input(x: Tensor, layer: Conv2d, kfac_approx: str) -> Tensor:
     """Process the input of a convolution before the self-inner product.
 
     Args:
-        a: Input to the convolution.
+        x: Input to the convolution. Has shape `[batch_size, C_in, I1, I2]`.
         layer: The convolution layer.
         kfac_approx: The KFAC approximation to use. Possible values are
-            `'expand'` and `'reduce'`.
+            `"expand"` and `"reduce"`.
 
     Returns:
-        The processed input.
+        The processed input. Has shape
+        `[batch_size, O1 * O2, C_in // groups * K1 * K2 (+ 1)]` for `"reduce"` and
+        `[batch_size * O1 * O2, C_in // groups * K1 * K2 (+ 1)]` for `"expand"`.
+        The `+1` is active if the layer has a bias.
 
     Raises:
         NotImplementedError: If the convolution uses dilation or string-valued
@@ -90,22 +93,22 @@ def conv2d_process_input(a: Tensor, layer: Conv2d, kfac_approx: str) -> Tensor:
             "String-valued padding is not yet supported (only 2-tuples)."
         )
 
-    a = _extract_patches(
-        a, layer.kernel_size, layer.stride, layer.padding, layer.groups
+    x = _extract_patches(
+        x, layer.kernel_size, layer.stride, layer.padding, layer.groups
     )
 
     if kfac_approx == "expand":
         # KFAC-expand approximation
-        a = rearrange(a, "b o1_o2 c_in_k1_k2 -> (b o1_o2) c_in_k1_k2")
+        x = rearrange(x, "b o1_o2 c_in_k1_k2 -> (b o1_o2) c_in_k1_k2")
     else:
         # KFAC-reduce approximation
-        a = reduce(a, "b o1_o2 c_in_k1_k2 -> b c_in_k1_k2", "mean")
+        x = reduce(x, "b o1_o2 c_in_k1_k2 -> b c_in_k1_k2", "mean")
 
     if layer.bias is not None:
-        a = cat([a, a.new_ones(a.shape[0], 1)], dim=1)
+        x = cat([x, x.new_ones(x.shape[0], 1)], dim=1)
 
-    scale = sqrt(a.shape[0])
-    return a.div_(scale)
+    scale = sqrt(x.shape[0])
+    return x.div_(scale)
 
 
 def linear_process_input(x: Tensor, layer: Linear, kfac_approx: str) -> Tensor:
@@ -116,10 +119,12 @@ def linear_process_input(x: Tensor, layer: Linear, kfac_approx: str) -> Tensor:
             `...` is an arbitrary number of weight-shared dimensions.
         layer: The linear layer.
         kfac_approx: The KFAC approximation to use for linear weight-sharing
-            layers. Possible values are `'expand'` and `'reduce'`.
+            layers. Possible values are `"expand"` and `"reduce"`.
 
     Returns:
-        The processed input.
+        The processed input. Has shape `[batch_size, d_in (+ 1)]` for
+        `"reduce"` and `[batch_size * ..., d_in (+ 1)]` for `"reduce"`.
+        The `+1` is active if the layer has a bias.
     """
     if kfac_approx == "expand":
         # KFAC-expand approximation
@@ -145,13 +150,13 @@ def process_grad_output(
         module: The module.
         batch_averaged: Whether the loss is a mean over per-sample losses.
         kfac_approx: The KFAC approximation to use for linear weight-sharing
-            layers. Possible values are `'expand'` and `'reduce'`.
+            layers. Possible values are `"expand"` and `"reduce"`.
 
     Returns:
         The processed output gradient.
 
     Raises:
-        AssertionError: If `kfac_approx` is neither `'expand'` nor `'reduce'`.
+        AssertionError: If `kfac_approx` is neither `"expand"` nor `"reduce"`.
         NotImplementedError: If the module is not supported.
     """
     assert kfac_approx in {"expand", "reduce"}
@@ -179,11 +184,11 @@ def conv2d_process_grad_output(
         batch_averaged: Whether to multiply with the batch size.
         scaling: An additional scaling that will be applied to the gradient.
         kfac_approx: The KFAC approximation to use. Possible values are
-            `'expand'` and `'reduce'`.
+            `"expand"` and `"reduce"`.
 
     Returns:
         The processed scaled gradient. Has shape `[batch_size, C_out]` for
-        `'reduce'` and `[batch_size * O1 * O2, C_out]` for `'expand'`.
+        `"reduce"` and `[batch_size * O1 * O2, C_out]` for `"expand"`.
     """
     # The scaling by `sqrt(batch_size)` when `batch_averaged=True` assumes
     # that we are in the reduce setting, i.e. the number of loss terms equals
@@ -213,11 +218,11 @@ def linear_process_grad_output(
         batch_averaged: Whether to multiply with the batch size.
         scaling: An additional scaling that will be applied to the gradient.
         kfac_approx: The KFAC approximation to use for linear weight-sharing
-            layers. Possible values are `'expand'` and `'reduce'`.
+            layers. Possible values are `"expand"` and `"reduce"`.
 
     Returns:
-        The processed gradient. Has shape `[batch_size, d_out]` for `'expand'`
-        and `[batch_size * ..., d_out]` for `'reduce'`.
+        The processed gradient. Has shape `[batch_size, d_out]` for `"reduce"`
+        and `[batch_size * ..., d_out]` for `"expand"`.
     """
     if kfac_approx == "expand":
         # KFAC-expand approximation


### PR DESCRIPTION
Resolves #32.

This refactors the processing functions for layer inputs and grad outputs, extensively relying on `einops`. I also added in-place operations in the `_extract_patches` to save potential copies of the unfolded input, which can be huge.

Some things to keep in mind for the review:
- I tried to update docstrings, but might have forgotten some parts.
- Feedback if comments regarding shapes are required would be good.
- The code to handle `Linear` and `Conv2d` layers is extremely similar now. We could think about refactoring the `linear_process_input/conv2d_process_input` and `linear_process_grad_output/conv2d_process_grad_output` functions into one each (`process_input` and `process_grad_output`). Right now I believe it's better to keep both separate; at least until we've ironed out support for dilated convolutions and string-valued padding. 