### PR TITLE
[REQ] Use `torch>=2.2.0`, deprecate `supported_{matmul,conv1d,einsum}`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
     numpy
-    torch
+    torch>=2.2.0
     einops
     einconv
 # The usage of test_requires is discouraged, see `Dependency Management` docs

--- a/singd/structures/base.py
+++ b/singd/structures/base.py
@@ -205,7 +205,8 @@ class StructuredMatrix(ABC):
             A dense PyTorch tensor resulting from the multiplication.
         """
         self._warn_naive_implementation("rmatmat")
-        return self.to_dense().T @ mat
+        dense = self.to_dense()
+        return dense.T @ mat.to(dense.dtype)
 
     @classmethod
     def _warn_naive_implementation(cls, fn_name: str):

--- a/singd/structures/base.py
+++ b/singd/structures/base.py
@@ -205,8 +205,7 @@ class StructuredMatrix(ABC):
             A dense PyTorch tensor resulting from the multiplication.
         """
         self._warn_naive_implementation("rmatmat")
-        dense = self.to_dense()
-        return dense.T @ mat.to(dense.dtype)
+        return self.to_dense().T @ mat
 
     @classmethod
     def _warn_naive_implementation(cls, fn_name: str):

--- a/singd/structures/hierarchical.py
+++ b/singd/structures/hierarchical.py
@@ -13,7 +13,6 @@ from singd.structures.utils import (
     lowest_precision,
     supported_einsum,
     supported_eye,
-    supported_matmul,
 )
 
 
@@ -209,34 +208,25 @@ class HierarchicalMatrixTemplate(StructuredMatrix):
                 [self.K1, self.diag_dim, self.K2]
             )
 
-            top = (
-                supported_matmul(self.A, other_top)
-                + supported_matmul(B_C, other_middle)
-                + supported_matmul(B_E, other_bottom)
-            )
+            top = self.A @ other_top + B_C @ other_middle + B_E @ other_bottom
             middle = supported_einsum("i,ij->ij", self.C, other_middle)
-            bottom = supported_matmul(self.D, other_middle) + supported_matmul(
-                self.E, other_bottom
-            )
+            bottom = self.D @ other_middle + self.E @ other_bottom
 
             return cat([top, middle, bottom], dim=0)
 
         else:
-            A_new = supported_matmul(self.A, other.A)
+            A_new = self.A @ other.A
             C_new = self.C * other.C
-            E_new = supported_matmul(self.E, other.E)
-            D_new = supported_einsum("ij,j->ij", self.D, other.C) + supported_matmul(
-                self.E, other.D
-            )
+            E_new = self.E @ other.E
+            D_new = supported_einsum("ij,j->ij", self.D, other.C) + self.E @ other.D
 
             B_C_other, B_E_other = other.B.split([other.diag_dim, other.K2], dim=1)
             B_new = cat(
                 [
-                    supported_matmul(self.A, B_C_other)
+                    self.A @ B_C_other
                     + supported_einsum("ij,j->ij", B_C, other.C)
-                    + supported_matmul(B_E, other.D),
-                    supported_matmul(self.A, B_E_other)
-                    + supported_matmul(B_E, other.E),
+                    + B_E @ other.D,
+                    self.A @ B_E_other + B_E @ other.E,
                 ],
                 dim=1,
             )
@@ -291,20 +281,18 @@ class HierarchicalMatrixTemplate(StructuredMatrix):
         # parts of B that share columns with C, E
         B_C, B_E = self.B.split([self.diag_dim, self.K2], dim=1)
 
-        top = supported_matmul(self.A.T, mat_top)
+        top = self.A.T @ mat_top
 
         compute_dtype = lowest_precision(self.C.dtype, mat_middle.dtype)
         out_dtype = self.C.dtype
         middle = (
-            supported_matmul(B_C.T, mat_top)
+            B_C.T @ mat_top
             + supported_einsum(
                 "i,ij->ij", self.C.to(compute_dtype), mat_middle.to(compute_dtype)
             ).to(out_dtype)
-            + supported_matmul(self.D.T, mat_bottom)
+            + self.D.T @ mat_bottom
         )
-        bottom = supported_matmul(B_E.T, mat_top) + supported_matmul(
-            self.E.T, mat_bottom
-        )
+        bottom = B_E.T @ mat_top + self.E.T @ mat_bottom
 
         return cat([top, middle, bottom])
 
@@ -323,26 +311,22 @@ class HierarchicalMatrixTemplate(StructuredMatrix):
             `self.T @ X @ X^T @ self`.
         """
         if X is None:
-            A_new = supported_matmul(self.A.T, self.A)
-            B_new = 2 * supported_matmul(self.A.T, self.B)
+            A_new = self.A.T @ self.A
+            B_new = 2 * self.A.T @ self.B
 
             # parts of B that share columns with C, E
             B_C, B_E = self.B.split([self.diag_dim, self.K2], dim=1)
 
             C_new = self.C**2 + (B_C**2).sum(0) + (self.D**2).sum(0)
-            D_new = 2 * (
-                supported_matmul(B_E.T, B_C) + supported_matmul(self.E.T, self.D)
-            )
-            E_new = supported_matmul(self.E.T, self.E) + supported_matmul(B_E.T, B_E)
+            D_new = 2 * (B_E.T @ B_C + self.E.T @ self.D)
+            E_new = self.E.T @ self.E + B_E.T @ B_E
         else:
             S_A, S_C, S_E = self.rmatmat(X).split([self.K1, self.diag_dim, self.K2])
-            A_new = supported_matmul(S_A, S_A.T)
-            B_new = 2 * cat(
-                [supported_matmul(S_A, S_C.T), supported_matmul(S_A, S_E.T)], dim=1
-            )
+            A_new = S_A @ S_A.T
+            B_new = 2 * cat([S_A @ S_C.T, S_A @ S_E.T], dim=1)
             C_new = (S_C**2).sum(1)
-            D_new = 2 * supported_matmul(S_E, S_C.T)
-            E_new = supported_matmul(S_E, S_E.T)
+            D_new = 2 * S_E @ S_C.T
+            E_new = S_E @ S_E.T
 
         return self.__class__(A_new, B_new, C_new, D_new, E_new)
 

--- a/singd/structures/recursive.py
+++ b/singd/structures/recursive.py
@@ -107,6 +107,7 @@ class RecursiveTopRightMatrixTemplate(RecursiveStructuredMatrix):
                 [0., 0., 0., 3., 0.],
                 [0., 0., 0., 0., 3.]])
     """
+
     MAX_DIMS: Tuple[Union[int, float], Union[int, float]]
     CLS_A: Type[StructuredMatrix]
     CLS_C: Type[StructuredMatrix]
@@ -244,6 +245,7 @@ class RecursiveBottomLeftMatrixTemplate(RecursiveStructuredMatrix):
                 [2., 2., 2., 3., 0.],
                 [2., 2., 2., 0., 3.]])
     """
+
     MAX_DIMS: Tuple[Union[int, float], Union[int, float]]
     CLS_A: Type[StructuredMatrix]
     CLS_C: Type[StructuredMatrix]

--- a/singd/structures/triltoeplitz.py
+++ b/singd/structures/triltoeplitz.py
@@ -6,15 +6,10 @@ from typing import Union
 
 import torch
 from torch import Tensor, arange, cat, zeros
-from torch.nn.functional import pad
+from torch.nn.functional import conv1d, pad
 
 from singd.structures.base import StructuredMatrix
-from singd.structures.utils import (
-    all_traces,
-    lowest_precision,
-    supported_conv1d,
-    toeplitz_matmul,
-)
+from singd.structures.utils import all_traces, lowest_precision, toeplitz_matmul
 
 
 class TrilToeplitzMatrix(StructuredMatrix):
@@ -149,7 +144,7 @@ class TrilToeplitzMatrix(StructuredMatrix):
             # need to create fake channel dimensions
             conv_input = pad(other._lower_diags, (dim - 1, 0)).unsqueeze(0)
             conv_weight = col.flip(0).unsqueeze(0).unsqueeze(0)
-            mat_column = supported_conv1d(conv_input, conv_weight).squeeze(0)
+            mat_column = conv1d(conv_input, conv_weight).squeeze(0)
             return TrilToeplitzMatrix(mat_column)
 
     def rmatmat(self, mat: Tensor) -> Tensor:

--- a/singd/structures/triutoeplitz.py
+++ b/singd/structures/triutoeplitz.py
@@ -6,15 +6,10 @@ from typing import Union
 
 import torch
 from torch import Tensor, arange, cat, triu_indices, zeros
-from torch.nn.functional import pad
+from torch.nn.functional import conv1d, pad
 
 from singd.structures.base import StructuredMatrix
-from singd.structures.utils import (
-    all_traces,
-    lowest_precision,
-    supported_conv1d,
-    toeplitz_matmul,
-)
+from singd.structures.utils import all_traces, lowest_precision, toeplitz_matmul
 
 
 class TriuToeplitzMatrix(StructuredMatrix):
@@ -147,7 +142,7 @@ class TriuToeplitzMatrix(StructuredMatrix):
             # need to create fake channel dimensions
             conv_input = pad(other._upper_diags, (dim - 1, 0)).unsqueeze(0)
             conv_weight = row.flip(0).unsqueeze(0).unsqueeze(0)
-            mat_row = supported_conv1d(conv_input, conv_weight).squeeze(0)
+            mat_row = conv1d(conv_input, conv_weight).squeeze(0)
             return TriuToeplitzMatrix(mat_row)
 
     def rmatmat(self, mat: Tensor) -> Tensor:

--- a/singd/structures/utils.py
+++ b/singd/structures/utils.py
@@ -8,7 +8,6 @@ from torch import (
     arange,
     bfloat16,
     device,
-    einsum,
     eye,
     float16,
     float32,
@@ -50,40 +49,6 @@ def supported_eye(n: int, **kwargs: Any) -> Tensor:
         return eye(n, **kwargs, dtype=float32).to(dtype)
     else:
         return eye(n, **kwargs, dtype=dtype)
-
-
-def supported_einsum(equation, *operands: Tensor) -> Tensor:
-    """Compute an `einsum` with the same or higher numerical precision.
-
-    If the `einsum` is not supported on the hardware,
-    carry out the multiplication in single precision.
-
-    Args:
-        equation: The `einsum` equation.
-        operands: The operands to the `einsum`.
-
-    Returns:
-        The result of the `einsum` in the original precision.
-
-    Raises:
-        RuntimeError: If the operands are not on the same device.
-    """
-    devices = {m.device for m in operands}
-    if len(devices) > 1:
-        raise RuntimeError("Operands must be on the same device.")
-    dev = devices.pop()
-
-    # Use the first tensor's data type as the result's data type.
-    # The tensors may have different data types if `autocast` was used.
-    dtype = operands[0].dtype
-
-    # @ not supported on CPU for float16 (bfloat16 is supported)
-    convert = dtype == float16 and str(dev) == "cpu"
-
-    operands = tuple(m.to(float32) if convert else m for m in operands)
-    result = einsum(equation, *operands)
-
-    return result.to(dtype) if convert else result
 
 
 def all_traces(mat: Tensor) -> Tensor:

--- a/test/optim/test_kfac_like.py
+++ b/test/optim/test_kfac_like.py
@@ -1,6 +1,5 @@
 """Integration test: Train on MNIST using KFAC-like updates."""
 
-
 from torch import manual_seed
 from torch.nn import Conv2d, CrossEntropyLoss, Flatten, Linear, ReLU, Sequential
 from torch.utils.data import DataLoader

--- a/test/optim/test_optimizer.py
+++ b/test/optim/test_optimizer.py
@@ -1,6 +1,5 @@
 """Tests ``singd.optim.optimizer`` functionality."""
 
-
 from test.optim.utils import (
     check_preconditioner_dtypes,
     check_preconditioner_structures,

--- a/test/structures/test_utils.py
+++ b/test/structures/test_utils.py
@@ -18,14 +18,12 @@ from torch.nn.functional import conv1d
 from singd.structures.utils import all_traces, diag_add_
 
 
-def test_cpu_float16_matmul_unsupported():
-    """Test whether ``@`` between two ``float16`` tensors on CPU is unsupported."""
+def test_cpu_float16_matmul_supported():
+    """Test whether ``@`` between two ``float16`` tensors on CPU is supported."""
     cpu = device("cpu")
     mat1 = zeros((2, 2), dtype=float16, device=cpu)
     mat2 = zeros((2, 2), dtype=float16, device=cpu)
-
-    with raises(RuntimeError):
-        _ = mat1 @ mat2
+    _ = mat1 @ mat2
 
 
 def test_cpu_bfloat16_eye_unsupported():
@@ -35,24 +33,20 @@ def test_cpu_bfloat16_eye_unsupported():
         eye(2, dtype=bfloat16, device=cpu)
 
 
-def test_cpu_float16_einsum_unsupported():
-    """Test whether ``einsum`` is unsupported in ``float16`` on CPU."""
+def test_cpu_float16_einsum_supported():
+    """Test whether ``einsum`` is supported in ``float16`` on CPU."""
     cpu = device("cpu")
     mat1 = zeros((2, 2, 2), dtype=float16, device=cpu)
     mat2 = zeros((2, 2, 2), dtype=float16, device=cpu)
-
-    with raises(RuntimeError):
-        einsum("nij,njk->nik", mat1, mat2)
+    _ = einsum("nij,njk->nik", mat1, mat2)
 
 
-def test_cpu_float16_conv1d_unsupported():
-    """Test whether ``conv1d`` is unsupported in ``float16`` on CPU."""
+def test_cpu_float16_conv1d_supported():
+    """Test whether ``conv1d`` is supported in ``float16`` on CPU."""
     cpu = device("cpu")
     inputs = zeros((2, 2, 2), dtype=float16, device=cpu)
     kernel = zeros((2, 2, 1), dtype=float16, device=cpu)
-
-    with raises(RuntimeError):
-        conv1d(inputs, kernel)
+    _ = conv1d(inputs, kernel)
 
 
 def test_all_traces():

--- a/test/structures/test_utils.py
+++ b/test/structures/test_utils.py
@@ -1,5 +1,7 @@
 """Test utility functions of ``singd.structures``."""
 
+from sys import platform
+
 from pytest import raises
 from torch import (
     Tensor,
@@ -26,10 +28,13 @@ def test_cpu_float16_matmul_supported():
     _ = mat1 @ mat2
 
 
-def test_cpu_bfloat16_eye_unsupported():
-    """Test whether ``eye`` is unsupported in ``bfloat16`` on CPU."""
+def test_eye_support():
+    """Test whether ``eye`` is unsupported in ``bfloat16`` on MAC+CPU."""
     cpu = device("cpu")
-    with raises(RuntimeError):
+    if platform == "darwin":
+        with raises(RuntimeError):
+            eye(2, dtype=bfloat16, device=cpu)
+    else:
         eye(2, dtype=bfloat16, device=cpu)
 
 


### PR DESCRIPTION
Addresses #71. Please review this before #70.