### PR TITLE
[ADD] Method `from_mat_inner` to structured matrix interface

### DIFF
--- a/singd/structures/base.py
+++ b/singd/structures/base.py
@@ -281,7 +281,20 @@ class StructuredMatrix(ABC):
         """
         self._warn_naive_implementation("from_inner")
         S_dense = self.to_dense().T if X is None else self.rmatmat(X)
-        return self.from_dense(S_dense @ S_dense.T)
+        return self.from_mat_inner(S_dense)
+
+    @classmethod
+    def from_mat_inner(cls, X: Tensor) -> StructuredMatrix:
+        """Extract the represented structure from `X @ X^T`.
+
+        Args:
+            X: Arbitrary 2d tensor.
+
+        Returns:
+            The structured matrix extracted from `X @ X^T`.
+        """
+        cls._warn_naive_implementation("from_mat_inner")
+        return cls.from_dense(X @ X.T)
 
     # NOTE This operation should be removed long-term as implementing IF-KFAC
     # with `from_inner` is more efficient. For now, it will exist as it makes

--- a/singd/structures/blockdiagonal.py
+++ b/singd/structures/blockdiagonal.py
@@ -291,8 +291,7 @@ class BlockDiagonalMatrixTemplate(StructuredMatrix):
             The structured matrix extracted from `X @ X^T`.
         """
         dim = X.shape[0]
-        num_blocks = dim // cls.BLOCK_DIM
-        last_dim = dim - num_blocks * cls.BLOCK_DIM
+        num_blocks, last_dim = divmod(dim, cls.BLOCK_DIM)
         dims = {"block": num_blocks, "row": cls.BLOCK_DIM}
 
         X_blocks, X_last = X.split([num_blocks * cls.BLOCK_DIM, last_dim])

--- a/singd/structures/diagonal.py
+++ b/singd/structures/diagonal.py
@@ -148,6 +148,18 @@ class DiagonalMatrix(StructuredMatrix):
             mat_diag *= (X**2).sum(1)
         return DiagonalMatrix(mat_diag)
 
+    @classmethod
+    def from_mat_inner(cls, X: Tensor) -> DiagonalMatrix:
+        """Extract a structured matrix from `X @ X.T`.
+
+        Args:
+            X: Arbitrary 2d tensor.
+
+        Returns:
+            The structured matrix extracted from `X @ X^T`.
+        """
+        return DiagonalMatrix((X**2).sum(1))
+
     def from_inner2(self, XXT: Tensor) -> StructuredMatrix:
         """Represent the matrix diagonal of ``self.T @ XXT @ self``.
 

--- a/test/structures/utils.py
+++ b/test/structures/utils.py
@@ -481,6 +481,27 @@ class _TestStructuredMatrix(ABC):
 
     @mark.parametrize("dtype", DTYPES, ids=DTYPE_IDS)
     @mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
+    def test_from_mat_inner(self, dev: device, dtype: torch.dtype):
+        """Test structure extraction from `X @ X.T`.
+
+        Args:
+            dev: The device on which to run the test.
+            dtype: The data type of the matrices.
+        """
+        for dim in self.DIMS:
+            manual_seed(0)
+            X = rand((dim, 2 * dim), device=dev, dtype=dtype)
+
+            truth = self.project(X @ X.T)
+            report_nonclose(
+                truth,
+                self.STRUCTURED_MATRIX_CLS.from_mat_inner(X).to_dense(),
+                rtol=1e-2 if is_half_precision(X.dtype) else 1e-5,
+                atol=1e-6 if is_half_precision(X.dtype) else 1e-7,
+            )
+
+    @mark.parametrize("dtype", DTYPES, ids=DTYPE_IDS)
+    @mark.parametrize("dev", DEVICES, ids=DEVICE_IDS)
     def test_from_inner2(self, dev: device, dtype: torch.dtype):
         """Test structure extraction after self-inner product w/ intermediate matrix.
 


### PR DESCRIPTION
Adds an interface function `from_mat_inner` which extracts a structured matrix from `X @ X.T` where `X` is an arbitrary 2d tensor. This addresses https://github.com/f-dangel/sirfshampoo/issues/24.  

This function is useful for speeding up `SIRFShampoo`'s update which takes a matrix view `G` of the gradient, then extracts a structured matrix of `G @ G.T`. So far, we were [mimicking this](https://github.com/f-dangel/sirfshampoo/blob/036ac235b3f192526a934eacc2d8b89c371aa24a/sirfshampoo/optimizer.py#L477-L482) computation by creating a structured matrix `I` which represents the identity matrix, then call `I.from_inner(G)` which computes the structured matrix of `I.T @ G @ G.T @ I`, effectively multiplying the identity matrix onto `G` before extracting the structured matrix. The new function `from_mat_inner` removes the unnecessary multiplication with identity.